### PR TITLE
Update default Gemini model to gemini-2.5-flash-preview-05-20.

### DIFF
--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -58,7 +58,7 @@ function loadConfig() {
         // Google Gemini API
         gemini: {
             apiKey: process.env.GEMINI_API_KEY,
-            modelId: process.env.GEMINI_MODEL_ID || 'gemini-2.0-flash-001',
+            modelId: process.env.GEMINI_MODEL_ID || 'gemini-2.5-flash-preview-05-20',
         },
 
         // Application Behavior


### PR DESCRIPTION
The previous default model was gemini-2.0-flash-001. This change updates the default model ID in the configuration loader.