### PR TITLE
Fix 24-hour time formatting in getCurrentTime

### DIFF
--- a/src/lib/timeUtils.js
+++ b/src/lib/timeUtils.js
@@ -13,6 +13,7 @@ const getCurrentTime = (timezoneOrOptions = 'UTC') => {
         minute: '2-digit',
         second: '2-digit',
         hour12: false, // Use 24-hour format for clarity
+        hourCycle: 'h23', // Ensure hours stay within 00-23
         timeZoneName: 'short', // e.g., UTC, PST, BST
         weekday: 'long',
         year: 'numeric',
@@ -37,3 +38,4 @@ const getCurrentTime = (timezoneOrOptions = 'UTC') => {
 export function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+


### PR DESCRIPTION
## Summary
- ensure the time formatter uses the h23 hour cycle so midnight renders as 00 instead of 24
- add a trailing newline to `src/lib/timeUtils.js`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69070da879e08329aef400a469a9a3be

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `getCurrentTime` uses 24-hour `h23` hour cycle so hours stay 00–23 (midnight renders as 00).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 642aefa07ab70ab4fe8b653c7ce4d0fdb0bcc65d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->