### PR TITLE
Claude/fix response cutoff 01 gbdh az juz zed4rrw kkpte r

### DIFF
--- a/src/components/commands/handlers/ask.js
+++ b/src/components/commands/handlers/ask.js
@@ -80,7 +80,8 @@ function extractLocationFromTimeQuery(userQuery) {
  * @param {string} userQuery - The original query for context.
  */
 async function handleAskResponseFormatting(channel, userName, responseText, userQuery, replyToId) {
-    logger.info({ responseLength: responseText?.length, userQuery }, `handleAskResponseFormatting called for ${userName}`);
+    const initialLength = responseText?.length || 0;
+    logger.info(`[!ask] Response received for ${userName}: ${initialLength} chars`);
 
     if (!responseText?.trim()) {
         logger.warn(`LLM returned no answer for !ask query "${userQuery}" from ${userName}`);
@@ -94,7 +95,13 @@ async function handleAskResponseFormatting(channel, userName, responseText, user
     // Remove markdown asterisks
     finalReplyText = removeMarkdownAsterisks(finalReplyText);
 
+    const finalLength = finalReplyText.length;
+    if (finalLength !== initialLength) {
+        logger.info(`[!ask] After cleanup: ${finalLength} chars (removed ${initialLength - finalLength} chars)`);
+    }
+
     // Let ircSender.js handle all length processing (summarization/truncation)
+    logger.info(`[!ask] Enqueueing message (${finalLength} chars) for ${userName}`);
     enqueueMessage(channel, finalReplyText, { replyToId });
 }
 

--- a/src/components/llm/geminiClient.js
+++ b/src/components/llm/geminiClient.js
@@ -485,7 +485,8 @@ export async function generateStandardResponse(contextPrompt, userQuery) {
             logger.warn({ response }, 'Gemini response missing extractable text.');
             return null;
         }
-        logger.info({ responseLength: text.length, responsePreview: text.substring(0, 50) }, 'Standard response .');
+        logger.info(`[LLM] Standard response generated: ${text.length} chars`);
+        logger.debug({ responsePreview: text.substring(0, 100) }, 'Response preview');
         return text;
     } catch (error) {
         logger.error({ err: error }, 'Error during standard generateContent call');
@@ -559,8 +560,10 @@ export async function generateSearchResponse(contextPrompt, userQuery) {
             logger.warn('Search-grounded Gemini response candidate missing extractable text.');
             return null;
         }
-        logger.info({ responseLength: text.length, responsePreview: text.substring(0, 50) }, 'Search-grounded response.');
-        return text.trim();
+        const trimmedText = text.trim();
+        logger.info(`[LLM] Search-grounded response generated: ${trimmedText.length} chars`);
+        logger.debug({ responsePreview: trimmedText.substring(0, 100) }, 'Response preview');
+        return trimmedText;
     } catch (error) {
         logger.error({ err: error }, 'Error during search-grounded generateContent call');
         return null;

--- a/src/components/llm/geminiClient.js
+++ b/src/components/llm/geminiClient.js
@@ -399,7 +399,7 @@ export async function generateStandardResponse(contextPrompt, userQuery) {
     // --- Add CRITICAL INSTRUCTION to systemInstruction ---
     const standardSystemInstruction = `${CHAT_SAGE_SYSTEM_INSTRUCTION}\n\nCRITICAL INSTRUCTION: If the User Query asks for the current time or date, you MUST call the 'getCurrentTime' function tool to get the accurate information. Do NOT answer time/date queries from your internal knowledge.`;
 
-    const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nREPLY: ≤300 chars. Prioritize substance; when helpful add a specific detail/fact/tip tied to the user's topic, and optionally a short, tailored question. No meta. Don't restate the question or context. Don't repeat the username. Reference chat history by username.`;
+    const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nREPLY: ≤450 chars. Prioritize substance; when helpful add a specific detail/fact/tip tied to the user's topic, and optionally a short, tailored question. No meta. Don't restate the question or context. Don't repeat the username. Reference chat history by username.`;
 
     logger.debug({ promptLength: fullPrompt.length }, 'Generating standard (no search) response');
 
@@ -503,7 +503,7 @@ export async function generateStandardResponse(contextPrompt, userQuery) {
 export async function generateSearchResponse(contextPrompt, userQuery) {
     if (!userQuery?.trim()) { return null; }
     const model = getGeminiClient();
-    const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nIMPORTANT: Search the web for up-to-date information to answer this question. Your response MUST be 420 characters or less (strict limit). Provide a direct, complete answer based on your search results. Include specific details from sources. Write complete sentences that fit within the limit. Reference chat history by username.`;
+    const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nIMPORTANT: Search the web for up-to-date information to answer this question. Your response MUST be ≤450 characters (strict limit). Provide a direct, complete answer based on your search results. Include specific details from sources. Write complete sentences that fit within the limit. Reference chat history by username.`;
     logger.debug({ promptLength: fullPrompt.length }, 'Generating search-grounded response');
 
     try {
@@ -577,7 +577,7 @@ export async function generateSearchResponse(contextPrompt, userQuery) {
 export async function generateUnifiedResponse(contextPrompt, userQuery) {
     if (!userQuery?.trim()) return null;
     const model = getGeminiClient();
-    const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nREPLY: ≤320 chars, direct, grounded if needed. No meta. Reference chat history by username.`;
+    const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nREPLY: ≤450 chars, direct, grounded if needed. No meta. Reference chat history by username.`;
     try {
         const result = await model.generateContent({
             contents: [{ role: 'user', parts: [{ text: fullPrompt }] }],

--- a/src/components/llm/llmUtils.js
+++ b/src/components/llm/llmUtils.js
@@ -34,7 +34,7 @@ export function getUserFriendlyErrorMessage(error) {
     return "Sorry, an error occurred while processing that.";
 }
 
-const MAX_IRC_MESSAGE_LENGTH = 450;
+const MAX_IRC_MESSAGE_LENGTH = 500; // Twitch IRC message limit
 const SUMMARY_TARGET_LENGTH = 400;
 // Removes chain-of-thought or meta sections the model may emit
 function stripMetaThoughts(text) {
@@ -215,15 +215,15 @@ export async function handleStandardLlmQuery(channel, cleanChannel, displayName,
                 finalReplyText = removeMarkdownAsterisks(summary);
                 logger.info(`Summarization successful (${finalReplyText.length} chars).`);
             } else {
-                logger.warn(`Summarization failed or returned empty for ${triggerType} response. Falling back to truncation.`);
-                finalReplyText = removeMarkdownAsterisks(initialResponseText.substring(0, MAX_IRC_MESSAGE_LENGTH - 3) + '...');
+                logger.warn(`Summarization failed or returned empty for ${triggerType} response. Falling back to smart truncation.`);
+                finalReplyText = smartTruncate(removeMarkdownAsterisks(initialResponseText), MAX_IRC_MESSAGE_LENGTH);
             }
         }
 
         // e. Final length check and Send
         if (finalReplyText.length > MAX_IRC_MESSAGE_LENGTH) {
-             logger.warn(`Final reply (even after summary/truncation) too long (${finalReplyText.length} chars). Truncating sharply.`);
-             finalReplyText = removeMarkdownAsterisks(finalReplyText.substring(0, MAX_IRC_MESSAGE_LENGTH - 3) + '...');
+             logger.warn(`Final reply (even after summary/truncation) too long (${finalReplyText.length} chars). Applying smart truncation.`);
+             finalReplyText = smartTruncate(finalReplyText, MAX_IRC_MESSAGE_LENGTH);
         }
         await sendBotResponse(channel, finalReplyText, { replyToId });
 

--- a/src/components/llm/llmUtils.js
+++ b/src/components/llm/llmUtils.js
@@ -108,7 +108,8 @@ export function smartTruncate(text, maxLength) {
     }
 
     // Hard truncation as last resort (add period for completeness)
-    return truncated.trim() + '.';
+    // Reserve space for the period to ensure result doesn't exceed maxLength
+    return text.substring(0, maxLength - 1).trim() + '.';
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increases IRC message limit to 500, caps LLM replies at ≤450 chars, switches to smart truncation/summarization, and adds clearer logging across ask handler, LLM client, and IRC sender.
> 
> - **Response length & limits**
>   - Increase `MAX_IRC_MESSAGE_LENGTH` to `500` and set summary target to `400` in `llmUtils.js` and `ircSender.js`.
>   - Standard/search/unified prompts updated to produce ≤450 chars in `geminiClient.js`.
> - **Truncation & summarization**
>   - Replace naive substring/ellipsis with `smartTruncate(...)` in `llmUtils.js` fallbacks and final checks.
>   - Ensure hard truncation reserves space for final period in `smartTruncate`.
>   - `ircSender.js`: summarize-then-intelligently-truncate flow with final safety checks.
> - **Logging improvements**
>   - `ask.js`: log initial/cleaned lengths and enqueue actions.
>   - `geminiClient.js`: clearer info/debug logs and previews for standard/search responses.
>   - `ircSender.js`: detailed logs for summarization, truncation, and queueing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d280199ca003b6171405ee29b41c6a4a474d83c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->