### PR TITLE
Add thinking level parameter support

### DIFF
--- a/src/components/llm/gemini/decision.js
+++ b/src/components/llm/gemini/decision.js
@@ -75,8 +75,7 @@ Output JSON only.`;
                 temperature: 0,
                 maxOutputTokens: 80,
                 responseMimeType: 'text/json', // Using text/json as schema enforcement is strict enough; application/json sometimes stricter
-                responseSchema: schema,
-                thinkingConfig: { thinkingLevel: 'low' }
+                responseSchema: schema
             }
         });
         const response = result;

--- a/src/components/llm/gemini/generation.js
+++ b/src/components/llm/gemini/generation.js
@@ -51,8 +51,7 @@ Respond with ONLY the valid IANA timezone string. If the location is ambiguous, 
             contents: [{ role: 'user', parts: [{ text: prompt }] }],
             config: {
                 temperature: 0.2,
-                maxOutputTokens: 50,
-                thinkingConfig: { thinkingLevel: 'low' } // Ensure low latency for this specialized lookup
+                maxOutputTokens: 50
             }
         });
         const response = result;
@@ -122,7 +121,6 @@ async function handleFunctionCall(functionCall) {
  */
 export async function generateStandardResponse(contextPrompt, userQuery, options = {}) {
     const model = getGeminiClient();
-    const thinkingLevel = options.thinkingLevel || 'low';
 
     // --- Add CRITICAL INSTRUCTION to systemInstruction ---
     const standardSystemInstruction = `${CHAT_SAGE_SYSTEM_INSTRUCTION}\n\nCRITICAL INSTRUCTION: If the User Query asks for the current time or date, you MUST call the 'getCurrentTime' function tool to get the accurate information. Do NOT answer time/date queries from your internal knowledge.`;
@@ -141,8 +139,7 @@ export async function generateStandardResponse(contextPrompt, userQuery, options
             systemInstruction: { parts: [{ text: standardSystemInstruction }] },
             generationConfig: {
                 maxOutputTokens: 1024,
-                responseMimeType: 'text/plain',
-                thinkingConfig: { thinkingLevel }
+                responseMimeType: 'text/plain'
             }
         });
         const response = result;
@@ -177,8 +174,7 @@ export async function generateStandardResponse(contextPrompt, userQuery, options
                         systemInstruction: { parts: [{ text: standardSystemInstruction }] },
                         generationConfig: {
                             maxOutputTokens: 512,
-                            responseMimeType: 'text/plain',
-                            thinkingConfig: { thinkingLevel }
+                            responseMimeType: 'text/plain'
                         }
                     });
                     const followupResponse = followup;
@@ -240,7 +236,6 @@ export async function generateStandardResponse(contextPrompt, userQuery, options
 export async function generateSearchResponse(contextPrompt, userQuery, options = {}) {
     if (!userQuery?.trim()) { return null; }
     const model = getGeminiClient();
-    const thinkingLevel = options.thinkingLevel || 'low';
     const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nIMPORTANT: Search the web for up-to-date information to answer this question. Your response MUST be 420 characters or less (strict limit). Provide a direct, complete answer based on your search results. Include specific details from sources. Write complete sentences that fit within the limit.`;
     logger.debug({ promptLength: fullPrompt.length }, 'Generating search-grounded response');
 
@@ -252,8 +247,7 @@ export async function generateSearchResponse(contextPrompt, userQuery, options =
             systemInstruction: { parts: [{ text: CHAT_SAGE_SYSTEM_INSTRUCTION }] },
             generationConfig: {
                 maxOutputTokens: 1536,
-                responseMimeType: 'text/plain',
-                thinkingConfig: { thinkingLevel }
+                responseMimeType: 'text/plain'
             }
         });
 
@@ -322,7 +316,6 @@ export async function generateSearchResponse(contextPrompt, userQuery, options =
 export async function generateUnifiedResponse(contextPrompt, userQuery, options = {}) {
     if (!userQuery?.trim()) return null;
     const model = getGeminiClient();
-    const thinkingLevel = options.thinkingLevel || 'low';
     const fullPrompt = `${contextPrompt}\n\nUSER: ${userQuery}\nREPLY: ≤320 chars, direct, grounded if needed. Answer the question directly. No meta.`;
     try {
         const result = await model.generateContent({
@@ -332,8 +325,7 @@ export async function generateUnifiedResponse(contextPrompt, userQuery, options 
             systemInstruction: { parts: [{ text: CHAT_SAGE_SYSTEM_INSTRUCTION }] },
             generationConfig: {
                 maxOutputTokens: 1024,
-                responseMimeType: 'text/plain',
-                thinkingConfig: { thinkingLevel }
+                responseMimeType: 'text/plain'
             }
         });
         const response = result;
@@ -418,8 +410,7 @@ ${textToSummarize}`;
                     propertyOrdering: ['summary']
                 },
                 maxOutputTokens: 320,
-                temperature: 0.3,
-                thinkingConfig: { thinkingLevel: options.thinkingLevel || 'low' }
+                temperature: 0.3
             }
         });
     }


### PR DESCRIPTION
…reasoning depth.

Previously, thinkingLevel was explicitly set to 'low' in multiple locations to optimize for lower latency. This change removes all thinkingConfig specifications, allowing Gemini 3 models to default to 'high' thinking level for maximum reasoning depth and more carefully reasoned outputs.

Changes:
- Removed thinkingConfig from decision.js (1 location)
- Removed thinkingConfig from generation.js (6 locations)
- Removed thinkingLevel parameter handling from function signatures