### PR TITLE
feat: Enable native language generation for minigames (trivia, riddle…

### DIFF
--- a/src/components/geo/geoClueService.js
+++ b/src/components/geo/geoClueService.js
@@ -27,13 +27,14 @@ const GeoRevealSchema = {
 /**
  * Generates the initial clue for a location using Structured Output.
  */
-export async function generateInitialClue(locationName, difficulty = 'normal', mode = 'real', gameTitle = null) {
+export async function generateInitialClue(locationName, difficulty = 'normal', mode = 'real', gameTitle = null, language = null) {
+    const languageDirective = language ? `\nIMPORTANT: Generate the clue entirely in ${language}. Do NOT use English.` : '';
     const prompt = `You are the Geo-Game Clue Generator. Generate the FIRST clue for the location "${locationName}" for a geography guessing game.${mode === 'game' && gameTitle ? ` The location is from the video game "${gameTitle}".` : ''}
 Difficulty: ${difficulty}
 - Focus on sensory details (sight, sound, smell, feeling) or atmosphere.
 - Hint subtly at the region/context.
 - Do NOT reveal the location name.
-- Return a single engaging sentence in JSON.`;
+- Return a single engaging sentence in JSON.${languageDirective}`;
 
     const model = getGeminiClient();
     try {
@@ -63,7 +64,7 @@ Difficulty: ${difficulty}
 /**
  * Generates a follow-up clue for a location using Structured Output.
  */
-export async function generateFollowUpClue(locationName, previousClues = [], mode = 'real', gameTitle = null, clueNumber = 2, incorrectGuessReasons = []) {
+export async function generateFollowUpClue(locationName, previousClues = [], mode = 'real', gameTitle = null, clueNumber = 2, incorrectGuessReasons = [], language = null) {
     let reasonGuidance = '';
     if (incorrectGuessReasons && incorrectGuessReasons.length > 0) {
         const uniqueReasons = [...new Set(incorrectGuessReasons)].filter(r => r.trim() !== '');
@@ -73,12 +74,13 @@ Recent incorrect guesses suggest confusion about: ${uniqueReasons.join('; ')}. U
         }
     }
 
+    const languageDirective = language ? `\nIMPORTANT: Generate the clue entirely in ${language}. Do NOT use English.` : '';
     const prompt = `Generate a NEW clue for "${locationName}".${mode === 'game' && gameTitle ? ` Game: "${gameTitle}".` : ''}
 Previous clues: ${previousClues.length ? previousClues.map((c, i) => `(${i + 1}) ${c}`).join(' | ') : 'None'}${reasonGuidance}
 - Do NOT repeat previous info.
 - Make it slightly more specific (unique feature, history, culture).
 - Do NOT give away the answer directly.
-- Return a single engaging sentence in JSON.`;
+- Return a single engaging sentence in JSON.${languageDirective}`;
 
     const model = getGeminiClient();
     try {
@@ -108,7 +110,7 @@ Previous clues: ${previousClues.length ? previousClues.map((c, i) => `(${i + 1})
 /**
  * Generates a final reveal for the location using Structured Output.
  */
-export async function generateFinalReveal(locationName, mode = 'real', gameTitle = null, reason = "unknown") {
+export async function generateFinalReveal(locationName, mode = 'real', gameTitle = null, reason = "unknown", language = null) {
     let outcomeInstruction = "";
     if (reason === "guessed") {
         outcomeInstruction = `The win has been announced. detailed summary ONLY.`;
@@ -120,11 +122,12 @@ export async function generateFinalReveal(locationName, mode = 'real', gameTitle
         outcomeInstruction = `Summary for "${locationName}".`;
     }
 
+    const languageDirective = language ? `\nIMPORTANT: Generate the reveal/summary entirely in ${language}. Do NOT use English.` : '';
     const prompt = `Generate a reveal/summary for "${locationName}". ${outcomeInstruction}
 ${mode === 'game' && gameTitle ? ` Game: "${gameTitle}".` : ''}
 - Interesting facts/context.
 - Engaging for Twitch chat.
-- Return a short paragraph (2-4 sentences) in JSON.`;
+- Return a short paragraph (2-4 sentences) in JSON.${languageDirective}`;
 
     const model = getGeminiClient();
     try {

--- a/src/components/geo/geoGameManager.js
+++ b/src/components/geo/geoGameManager.js
@@ -269,7 +269,7 @@ async function _transitionToEnding(gameState, reason = "guessed", timeTakenMs = 
         roundEndMessage = "An error occurred, and the round's location couldn't be revealed.";
     } else {
         try {
-            revealText = await generateFinalReveal(gameState.targetLocation.name, gameState.mode, gameState.gameTitleScope, reason);
+            revealText = await generateFinalReveal(gameState.targetLocation.name, gameState.mode, gameState.gameTitleScope, reason, gameState.botLanguage || null);
             let baseMessageContent = "";
             const roundPrefix = isMultiRound ? `(Round ${gameState.currentRound}/${gameState.totalRounds}) ` : "";
             if (reason === "guessed" && gameState.winner) {
@@ -469,7 +469,7 @@ async function _startNextRound(gameState) {
     // 2. Generate Initial Clue
     // Pass the correct scope (game title for game mode, null for real mode as region is handled by selection)
     const clueScope = gameState.mode === 'game' ? gameState.gameTitleScope : null;
-    const firstClue = await generateInitialClue(gameState.targetLocation.name, gameState.config.difficulty, gameState.mode, clueScope);
+    const firstClue = await generateInitialClue(gameState.targetLocation.name, gameState.config.difficulty, gameState.mode, clueScope, gameState.botLanguage || null);
     if (!firstClue) {
         logger.error(`[GeoGame][${gameState.channelName}] CRITICAL: Failed to generate initial clue for round ${gameState.currentRound}. Ending game prematurely.`);
         enqueueMessage(`#${gameState.channelName}`, `⚠️ Error: Could not generate a clue for round ${gameState.currentRound}. Ending the game.`);
@@ -502,7 +502,8 @@ async function _startNextRound(gameState) {
     }
 
     const clueMessage = formatClueMessage(1, firstClue); // Clue #1 for Round 1
-    enqueueMessage(`#${gameState.channelName}`, clueMessage);
+    // Skip translation if clue was generated natively in the target language
+    enqueueMessage(`#${gameState.channelName}`, clueMessage, { skipTranslation: !!gameState.botLanguage });
 
     // Transition to 'inProgress' for the new round
     gameState.state = 'inProgress';
@@ -574,7 +575,8 @@ async function _scheduleNextClue(gameState) {
                 gameState.mode,
                 gameState.gameTitleScope,
                 gameState.currentClueIndex + 2, // Clue number within the round
-                gameState.incorrectGuessReasons // Reasons from the *current round*
+                gameState.incorrectGuessReasons, // Reasons from the *current round*
+                gameState.botLanguage || null // Native language generation
             );
             if (nextClue) {
                 // Check state again *after* await
@@ -586,7 +588,8 @@ async function _scheduleNextClue(gameState) {
                 gameState.currentClueIndex++;
                 // Use currentClueIndex + 1 for the user-facing clue number
                 const clueMessage = formatClueMessage(gameState.currentClueIndex + 1, nextClue);
-                enqueueMessage(`#${gameState.channelName}`, clueMessage);
+                // Skip translation if clue was generated natively in the target language
+                enqueueMessage(`#${gameState.channelName}`, clueMessage, { skipTranslation: !!gameState.botLanguage });
 
                 // Only schedule the next clue if still in progress
                 if (gameState.state === 'inProgress') {
@@ -644,6 +647,14 @@ async function _startGameProcess(channelName, mode, scope = null, initiatorUsern
     gameState.guessCache = new Map();
     gameState.gameSessionExcludedLocations = new Set(); // Reset for the new game session
     _clearTimers(gameState); // Ensure no stray timers
+
+    // Look up botLanguage for native generation
+    const contextManager = getContextManager();
+    const botLanguage = contextManager.getBotLanguage(channelName);
+    gameState.botLanguage = botLanguage || null;
+    if (botLanguage) {
+        logger.info(`[GeoGame][${channelName}] Bot language is ${botLanguage}. Clues will be generated natively in ${botLanguage}.`);
+    }
 
     const scopeLog = scope ? (mode === 'game' ? `Game Scope: ${scope}` : `Region Scope: ${scope}`) : 'Scope: N/A';
     logger.info(`[GeoGame][${channelName}] Starting new game process. Mode: ${mode}, ${scopeLog}, Rounds: ${gameState.totalRounds}, Initiator: ${gameState.initiatorUsername}`);
@@ -703,7 +714,7 @@ async function _startGameProcess(channelName, mode, scope = null, initiatorUsern
         // 2. Generate Initial Clue (Round 1)
         // Pass game title only if game mode
         const clueScope = mode === 'game' ? gameState.gameTitleScope : null;
-        const firstClue = await generateInitialClue(gameState.targetLocation.name, gameState.config.difficulty, mode, clueScope);
+        const firstClue = await generateInitialClue(gameState.targetLocation.name, gameState.config.difficulty, mode, clueScope, gameState.botLanguage || null);
         if (!firstClue) {
             throw new Error("Failed to generate the initial clue for Round 1.");
         }
@@ -726,7 +737,8 @@ async function _startGameProcess(channelName, mode, scope = null, initiatorUsern
         }
 
         const clueMessage = formatClueMessage(1, firstClue); // Clue #1 for Round 1
-        enqueueMessage(`#${channelName}`, clueMessage);
+        // Skip translation if clue was generated natively in the target language
+        enqueueMessage(`#${channelName}`, clueMessage, { skipTranslation: !!gameState.botLanguage });
 
         // Transition to 'inProgress'
         gameState.state = 'inProgress';

--- a/src/components/riddle/riddleGameManager.js
+++ b/src/components/riddle/riddleGameManager.js
@@ -386,7 +386,8 @@ async function _startNextRound(gameState) {
                 gameState.currentRiddle.difficulty,
                 config.questionTimeSeconds
             );
-            enqueueMessage(`#${channelName}`, questionMsg);
+            // Skip translation if riddle was generated natively in the target language
+            enqueueMessage(`#${channelName}`, questionMsg, { skipTranslation: !!gameState.currentRiddle.language });
 
             const timeoutMs = (config.questionTimeSeconds || DEFAULT_RIDDLE_CONFIG.questionTimeSeconds) * 1000;
             gameState.riddleTimeoutTimer = setTimeout(async () => {
@@ -441,7 +442,7 @@ async function _startNextRound(gameState) {
 
     while (!generatedRiddle && retries < (config.maxRiddleGenerationRetries || DEFAULT_RIDDLE_CONFIG.maxRiddleGenerationRetries)) {
         try {
-            generatedRiddle = await generateRiddle(topic, config.difficulty, combinedExcludedKeywordSets, channelName, excludedAnswers);
+            generatedRiddle = await generateRiddle(topic, config.difficulty, combinedExcludedKeywordSets, channelName, excludedAnswers, gameState.botLanguage || null);
             if (generatedRiddle && generatedRiddle.question && generatedRiddle.answer && generatedRiddle.keywords) {
                 // Post-generation answer similarity check
                 if (_isAnswerTooSimilar(generatedRiddle.answer, excludedAnswers)) {
@@ -482,7 +483,8 @@ async function _startNextRound(gameState) {
         gameState.currentRiddle.difficulty,
         config.questionTimeSeconds
     );
-    enqueueMessage(`#${channelName}`, questionMsg);
+    // Skip translation if riddle was generated natively in the target language
+    enqueueMessage(`#${channelName}`, questionMsg, { skipTranslation: !!gameState.currentRiddle.language });
 
     const timeoutMs = (config.questionTimeSeconds || DEFAULT_RIDDLE_CONFIG.questionTimeSeconds) * 1000;
     gameState.riddleTimeoutTimer = setTimeout(async () => {
@@ -528,7 +530,8 @@ async function _prefetchNextRiddle(gameState) {
             config.difficulty,
             excludedKeywordSets,
             channelName,
-            excludedAnswers
+            excludedAnswers,
+            gameState.botLanguage || null // Native language generation
         );
 
         if (riddle && riddle.question && riddle.answer && riddle.keywords) {
@@ -581,7 +584,14 @@ async function _handleAnswer(channelName, username, displayName, message) {
 
     logger.debug(`[RiddleGameManager][${channelName}] Processing answer "${userAnswer}" from ${displayName} for round ${gameState.currentRound}`);
 
-    // Added: Translate user's answer if botlang is set
+    // Determine verification answer: use answerEnglish if available (native generation path)
+    let verifyAgainstAnswer = gameState.currentRiddle.answer;
+    if (gameState.currentRiddle.answerEnglish) {
+        verifyAgainstAnswer = gameState.currentRiddle.answerEnglish;
+        logger.debug(`[RiddleGameManager][${channelName}] Using English answer for verification: "${verifyAgainstAnswer}"`);
+    }
+
+    // Translate user's answer if botlang is set
     const contextManager = getContextManager();
     const botLanguage = contextManager.getBotLanguage(channelName);
     let answerToVerify = userAnswer;
@@ -600,12 +610,11 @@ async function _handleAnswer(channelName, username, displayName, message) {
             logger.error({ err: translateError, channelName, userAnswer, botLanguage }, `[RiddleGameManager][${channelName}] Failed to translate user answer to English for verification. Using original.`);
         }
     }
-    // End of added translation logic
 
     try {
         const originalRequestedTopic = gameState.topic;
         const verification = await verifyRiddleAnswer(
-            gameState.currentRiddle.answer,
+            verifyAgainstAnswer,
             answerToVerify, // Use the potentially translated answer
             gameState.currentRiddle.question,
             originalRequestedTopic
@@ -666,6 +675,14 @@ export async function startGame(channelName, topic = null, initiatorUsername = n
     gameState.startTime = null;
     gameState.winner = null;
     _clearTimers(gameState);
+
+    // Look up botLanguage for native generation
+    const contextManager = getContextManager();
+    const botLanguage = contextManager.getBotLanguage(channelName);
+    gameState.botLanguage = botLanguage || null;
+    if (botLanguage) {
+        logger.info(`[RiddleGameManager][${channelName}] Bot language is ${botLanguage}. Riddles will be generated natively in ${botLanguage}.`);
+    }
 
     gameState.state = 'selecting'; // Mark as selecting before async operations
 

--- a/src/components/riddle/riddleService.js
+++ b/src/components/riddle/riddleService.js
@@ -57,6 +57,19 @@ const RiddleSchema = {
     required: ["riddle_question", "riddle_answer", "keywords", "difficulty_generated", "explanation", "search_used"]
 };
 
+// Localized schema adds riddle_answer_english for answer verification when generating in non-English
+const LocalizedRiddleSchema = {
+    type: GenAIType.OBJECT,
+    properties: {
+        ...RiddleSchema.properties,
+        riddle_answer_english: {
+            type: GenAIType.STRING,
+            description: "The riddle answer translated to English. Used for answer verification. Must be concise (1-2 words)."
+        }
+    },
+    required: [...RiddleSchema.required, "riddle_answer_english"]
+};
+
 
 // Helper: prune excluded keyword sets to keep prompt small
 function pruneExcludedKeywordSets(excludedKeywordSets, options = {}) {
@@ -112,7 +125,7 @@ function pruneExcludedKeywordSets(excludedKeywordSets, options = {}) {
 /**
  * Generates a riddle using Structured Output and Search Grounding.
  */
-export async function generateRiddle(topic, difficulty, excludedKeywordSets = [], channelName, excludedAnswers = []) {
+export async function generateRiddle(topic, difficulty, excludedKeywordSets = [], channelName, excludedAnswers = [], language = null) {
     const model = getGeminiClient();
     let actualTopic = topic;
     let promptDetails = `Difficulty: ${difficulty}.`;
@@ -166,6 +179,11 @@ These have been used recently or are banned. Pick something COMPLETELY DIFFERENT
 
 
 
+    // Add language directive if generating in a non-English language
+    const languageDirective = language
+        ? `\nLANGUAGE: Generate the riddle_question, riddle_answer, and explanation entirely in ${language}. Also provide riddle_answer_english with the English translation of the answer for verification purposes.`
+        : '';
+
     const prompt = `You are a riddle crafter for a Twitch chat game. Create a riddle about "${actualTopic}" that is CLEVER but GUESSABLE.
 ${promptDetails}
 ${fullExclusionInstructions}
@@ -185,11 +203,16 @@ RULES FOR QUESTION:
 EXPLANATION STYLE:
 - Fun, conversational (Max 1-2 sentences). No academic tone.
 
-Return JSON matching the schema.`;
+Return JSON matching the schema.${languageDirective}`;
+
+    // Select schema based on whether we need the English answer field
+    const activeSchema = language ? LocalizedRiddleSchema : RiddleSchema;
 
     try {
         // Always provide Google Search tool — Gemini auto-decides whether to use it
         const tools = [{ googleSearch: {} }];
+
+        logger.debug({ topic: actualTopic, language }, `[RiddleService] Generating riddle via Structured Output.`);
 
         const result = await model.generateContent({
             contents: [{ role: "user", parts: [{ text: prompt }] }],
@@ -197,7 +220,7 @@ Return JSON matching the schema.`;
             generationConfig: {
                 temperature: 0.75,
                 responseMimeType: "application/json",
-                responseSchema: RiddleSchema
+                responseSchema: activeSchema
             }
         });
 
@@ -234,9 +257,9 @@ Return JSON matching the schema.`;
         // Derive searchUsed from actual response grounding metadata
         const actuallySearched = args.search_used || !!(result.candidates?.[0]?.groundingMetadata?.webSearchQueries?.length);
 
-        logger.info(`[RiddleService] Riddle generated for topic "${actualTopic}" (search=${actuallySearched}). Q: "${args.riddle_question}", A: "${args.riddle_answer}"`);
+        logger.info(`[RiddleService] Riddle generated for topic "${actualTopic}" (search=${actuallySearched}, lang=${language || 'en'}). Q: "${args.riddle_question}", A: "${args.riddle_answer}"`);
 
-        return {
+        const riddleObject = {
             question: args.riddle_question,
             answer: args.riddle_answer,
             keywords: args.keywords,
@@ -244,8 +267,17 @@ Return JSON matching the schema.`;
             explanation: args.explanation || "No explanation provided.",
             searchUsed: actuallySearched,
             topic: actualTopic,
-            requestedTopic: topic
+            requestedTopic: topic,
+            language: language || null
         };
+
+        // When generating in a non-English language, store English answer for verification
+        if (language && args.riddle_answer_english) {
+            riddleObject.answerEnglish = args.riddle_answer_english;
+            logger.debug(`[RiddleService] Localized answer: "${args.riddle_answer}" (English: "${args.riddle_answer_english}")`);
+        }
+
+        return riddleObject;
 
     } catch (error) {
         logger.error({ err: error, topic: actualTopic }, '[RiddleService] Error generating riddle');

--- a/src/components/trivia/triviaGameManager.js
+++ b/src/components/trivia/triviaGameManager.js
@@ -558,7 +558,8 @@ async function _startNextRound(gameState) {
                 gameState.currentQuestion.difficulty,
                 gameState.config.questionTimeSeconds
             );
-            enqueueMessage(`#${gameState.channelName}`, questionMessage);
+            // Skip translation if question was generated natively in the target language
+            enqueueMessage(`#${gameState.channelName}`, questionMessage, { skipTranslation: !!gameState.currentQuestion.language });
 
             const timeoutMs = gameState.config.questionTimeSeconds * 1000;
             gameState.questionEndTimer = setTimeout(async () => {
@@ -620,13 +621,13 @@ async function _startNextRound(gameState) {
 
     while (!questionGenerated && retries < MAX_QUESTION_RETRIES) {
         try {
-            // --- Pass excluded questions and answers to generateQuestion ---
             const question = await generateQuestion(
                 gameState.topic,
                 gameState.config.difficulty,
                 finalExcludedQuestionsArray, // Pass the combined list
                 gameState.channelName,
-                finalExcludedAnswersArray // Pass excluded answers
+                finalExcludedAnswersArray, // Pass excluded answers
+                gameState.botLanguage || null // Native language generation
             );
             // --- End modification ---
             if (
@@ -700,7 +701,8 @@ async function _startNextRound(gameState) {
         gameState.config.questionTimeSeconds
     );
 
-    enqueueMessage(`#${gameState.channelName}`, questionMessage);
+    // Skip translation if question was generated natively in the target language
+    enqueueMessage(`#${gameState.channelName}`, questionMessage, { skipTranslation: !!gameState.currentQuestion.language });
 
     // 4. Set Question Timer
     const timeoutMs = gameState.config.questionTimeSeconds * 1000;
@@ -766,7 +768,8 @@ async function _prefetchNextQuestion(gameState) {
             gameState.config.difficulty,
             excludedQuestions,
             channelName,
-            excludedAnswers
+            excludedAnswers,
+            gameState.botLanguage || null // Native language generation
         );
 
         // Validate before storing
@@ -849,30 +852,57 @@ async function _processAnswerAttempt(gameState, attempt) {
             return;
         }
 
-        // 2. Translation
-        const contextManager = getContextManager();
-        const botLanguage = contextManager.getBotLanguage(channelName);
+        // 2. Translation / English answer resolution
+        // If we have answerEnglish from native generation, use it directly for verification
+        // Otherwise, fall back to translating user answer to English
+        let verifyAgainstAnswer = gameState.currentQuestion.answer;
+        let verifyAgainstAlternates = gameState.currentQuestion.alternateAnswers || [];
 
-        if (botLanguage && botLanguage.toLowerCase() !== 'english' && botLanguage.toLowerCase() !== 'en') {
-            logger.debug(`[TriviaGame][${channelName}] Bot language is ${botLanguage}. Translating user answer "${attempt.answer}" to English for verification.`);
-            try {
-                const translatedUserAnswer = await translateText(attempt.answer, 'English');
-                if (translatedUserAnswer && typeof translatedUserAnswer === 'string' && translatedUserAnswer.trim().length > 0) {
-                    attempt.answerToVerify = translatedUserAnswer.trim();
-                    logger.info(`[TriviaGame][${channelName}] Translated user answer for verification: "${attempt.answer}" -> "${attempt.answerToVerify}"`);
-                } else {
-                    logger.warn(`[TriviaGame][${channelName}] Translation of answer "${attempt.answer}" to English resulted in empty string. Using original for verification.`);
+        if (gameState.currentQuestion.answerEnglish) {
+            // Native generation path: verify against English answers, translate user answer to English
+            verifyAgainstAnswer = gameState.currentQuestion.answerEnglish;
+            verifyAgainstAlternates = gameState.currentQuestion.alternateAnswersEnglish || gameState.currentQuestion.alternateAnswers || [];
+            logger.debug(`[TriviaGame][${channelName}] Using English answers for verification: "${verifyAgainstAnswer}"`);
+
+            // Still translate user answer to English for consistent comparison
+            const contextManager = getContextManager();
+            const botLanguage = contextManager.getBotLanguage(channelName);
+            if (botLanguage && botLanguage.toLowerCase() !== 'english' && botLanguage.toLowerCase() !== 'en') {
+                try {
+                    const translatedUserAnswer = await translateText(attempt.answer, 'English');
+                    if (translatedUserAnswer && typeof translatedUserAnswer === 'string' && translatedUserAnswer.trim().length > 0) {
+                        attempt.answerToVerify = translatedUserAnswer.trim();
+                        logger.info(`[TriviaGame][${channelName}] Translated user answer for verification: "${attempt.answer}" -> "${attempt.answerToVerify}"`);
+                    }
+                } catch (translateError) {
+                    logger.error({ err: translateError, channelName, userAnswer: attempt.answer }, `[TriviaGame][${channelName}] Failed to translate user answer to English. Using original.`);
                 }
-            } catch (translateError) {
-                logger.error({ err: translateError, channelName, userAnswer: attempt.answer, botLanguage }, `[TriviaGame][${channelName}] Failed to translate user answer to English for verification. Using original.`);
+            }
+        } else {
+            // Legacy path: translate user answer to English when botlang is set
+            const contextManager = getContextManager();
+            const botLanguage = contextManager.getBotLanguage(channelName);
+            if (botLanguage && botLanguage.toLowerCase() !== 'english' && botLanguage.toLowerCase() !== 'en') {
+                logger.debug(`[TriviaGame][${channelName}] Bot language is ${botLanguage}. Translating user answer "${attempt.answer}" to English for verification.`);
+                try {
+                    const translatedUserAnswer = await translateText(attempt.answer, 'English');
+                    if (translatedUserAnswer && typeof translatedUserAnswer === 'string' && translatedUserAnswer.trim().length > 0) {
+                        attempt.answerToVerify = translatedUserAnswer.trim();
+                        logger.info(`[TriviaGame][${channelName}] Translated user answer for verification: "${attempt.answer}" -> "${attempt.answerToVerify}"`);
+                    } else {
+                        logger.warn(`[TriviaGame][${channelName}] Translation of answer "${attempt.answer}" to English resulted in empty string. Using original for verification.`);
+                    }
+                } catch (translateError) {
+                    logger.error({ err: translateError, channelName, userAnswer: attempt.answer, botLanguage }, `[TriviaGame][${channelName}] Failed to translate user answer to English for verification. Using original.`);
+                }
             }
         }
 
         // 3. Verification
         const verificationResult = await verifyAnswer(
-            gameState.currentQuestion.answer,
+            verifyAgainstAnswer,
             attempt.answerToVerify, // Use the potentially translated answer
-            gameState.currentQuestion.alternateAnswers || [],
+            verifyAgainstAlternates,
             gameState.currentQuestion.question,
             gameState.topic || 'general'
         );
@@ -1019,6 +1049,14 @@ async function startGame(channelName, topic = null, initiatorUsername = null, nu
 
     logger.info(`[TriviaGame][${channelName}] Starting new game. Topic: ${topic || 'General'}, Rounds: ${gameState.totalRounds}, Initiator: ${gameState.initiatorUsername}`);
 
+    // Look up botLanguage for native generation
+    const contextManager = getContextManager();
+    const botLanguage = contextManager.getBotLanguage(channelName);
+    gameState.botLanguage = botLanguage || null;
+    if (botLanguage) {
+        logger.info(`[TriviaGame][${channelName}] Bot language is ${botLanguage}. Questions will be generated natively in ${botLanguage}.`);
+    }
+
     // Only send preamble if user specified rounds > 1 or a specific topic
     if (gameState.totalRounds > 1 || topic !== null) {
         const startMessage = formatStartMessage(
@@ -1063,13 +1101,13 @@ async function startGame(channelName, topic = null, initiatorUsername = null, nu
         }
         while (!questionGenerated && retries < MAX_QUESTION_RETRIES) {
             try {
-                // --- Pass excluded questions and answers to generateQuestion ---
                 const question = await generateQuestion(
                     topic,
                     gameState.config.difficulty,
                     finalExcludedQuestionsArray, // Pass current exclusion set
                     channelName,
-                    finalExcludedAnswersArray // Pass excluded answers
+                    finalExcludedAnswersArray, // Pass excluded answers
+                    gameState.botLanguage || null // Native language generation
                 );
                 // --- End modification ---
                 if (
@@ -1135,7 +1173,8 @@ async function startGame(channelName, topic = null, initiatorUsername = null, nu
             gameState.config.questionTimeSeconds
         );
 
-        enqueueMessage(`#${channelName}`, questionMessage);
+        // Skip translation if question was generated natively in the target language
+        enqueueMessage(`#${channelName}`, questionMessage, { skipTranslation: !!gameState.currentQuestion.language });
 
         // Set question timer
         const timeoutMs = gameState.config.questionTimeSeconds * 1000;

--- a/src/components/trivia/triviaQuestionService.js
+++ b/src/components/trivia/triviaQuestionService.js
@@ -43,6 +43,24 @@ const TriviaQuestionSchema = {
     required: ["question", "correct_answer", "explanation", "difficulty", "search_used", "category"]
 };
 
+// Localized schema adds correct_answer_english for answer verification when generating in non-English
+const LocalizedTriviaQuestionSchema = {
+    type: GenAIType.OBJECT,
+    properties: {
+        ...TriviaQuestionSchema.properties,
+        correct_answer_english: {
+            type: GenAIType.STRING,
+            description: "The correct answer translated to English. Used for answer verification. Must be concise (1-3 words)."
+        },
+        alternate_answers_english: {
+            type: GenAIType.ARRAY,
+            description: "The alternate answers translated to English for verification.",
+            items: { type: GenAIType.STRING }
+        }
+    },
+    required: [...TriviaQuestionSchema.required, "correct_answer_english"]
+};
+
 // --- Helper: Extract current game from context ---
 function getGameFromContext(channelName) {
     if (!channelName) return "video games";
@@ -91,9 +109,10 @@ export function calculateStringSimilarity(str1, str2) {
  * @param {string[]} excludedQuestions - Array of question texts to avoid regenerating.
  * @param {string|null} channelName
  * @param {string[]} excludedAnswers - Array of answer strings to avoid regenerating.
+ * @param {string|null} [language=null] - Optional target language for native generation.
  * @returns {Promise<object|null>}
  */
-export async function generateQuestion(topic, difficulty, excludedQuestions = [], channelName = null, excludedAnswers = []) {
+export async function generateQuestion(topic, difficulty, excludedQuestions = [], channelName = null, excludedAnswers = [], language = null) {
     const model = getGeminiClient();
 
     let specificTopic = topic;
@@ -125,6 +144,11 @@ export async function generateQuestion(topic, difficulty, excludedQuestions = []
         ? `Topic: "${specificTopic}".`
         : `Topic: General Knowledge.`;
 
+    // Add language directive if generating in a non-English language
+    const languageDirective = language
+        ? `\nLANGUAGE: Generate the question, correct_answer, alternate_answers, and explanation entirely in ${language}. Also provide correct_answer_english and alternate_answers_english with the English translations of the answers for verification purposes.`
+        : '';
+
     const prompt = `Generate an engaging trivia question.
 ${contextPrompt}
 Difficulty: ${difficulty}.
@@ -132,10 +156,13 @@ ${exclusionInstructionText}
 Be precise about entity types and relationships. Do not reveal the correct answer (or any alias) in the question text.
 Keep 'correct_answer' concise (1-3 words).
 Also set a generic 'category' describing the answer type (e.g., Person, Location, Event, Work Title, Scientific Term).
-Only use Google Search if the question requires very recent or obscure facts that may be beyond general knowledge.`;
+Only use Google Search if the question requires very recent or obscure facts that may be beyond general knowledge.${languageDirective}`;
+
+    // Select schema based on whether we need the English answer fields
+    const activeSchema = language ? LocalizedTriviaQuestionSchema : TriviaQuestionSchema;
 
     try {
-        logger.debug({ topic: specificTopic }, `[TriviaService] Generating question via Structured Output.`);
+        logger.debug({ topic: specificTopic, language }, `[TriviaService] Generating question via Structured Output.`);
 
         // Always provide Google Search tool — Gemini auto-decides whether to use it
         const tools = [{ googleSearch: {} }];
@@ -146,7 +173,7 @@ Only use Google Search if the question requires very recent or obscure facts tha
             generationConfig: {
                 temperature: 0.7,
                 responseMimeType: "application/json",
-                responseSchema: TriviaQuestionSchema
+                responseSchema: activeSchema
             }
         });
 
@@ -208,10 +235,18 @@ Only use Google Search if the question requires very recent or obscure facts tha
             searchUsed: actuallySearched,
             verified: true, // Structured output = implicitly verified
             topic: isGeneralTopic ? 'general' : specificTopic,
-            category: category || ""
+            category: category || "",
+            language: language || null
         };
 
-        logger.info(`[TriviaService] Successfully generated question (search=${actuallySearched}). Q: "${question}", A: "${correct_answer}"`);
+        // When generating in a non-English language, store English answers for verification
+        if (language && parsed.correct_answer_english) {
+            questionObject.answerEnglish = parsed.correct_answer_english;
+            questionObject.alternateAnswersEnglish = parsed.alternate_answers_english || [];
+            logger.debug(`[TriviaService] Localized answer: "${correct_answer}" (English: "${parsed.correct_answer_english}")`);
+        }
+
+        logger.info(`[TriviaService] Successfully generated question (search=${actuallySearched}, lang=${language || 'en'}). Q: "${question}", A: "${correct_answer}"`);
         return questionObject;
 
     } catch (error) {

--- a/src/lib/translationUtils.js
+++ b/src/lib/translationUtils.js
@@ -259,6 +259,7 @@ Rules:
 1. If the text is already in ${targetLanguage}, set same_language to true and leave translated_text empty.
 2. Otherwise, set same_language to false and provide the translation in translated_text.
 3. Output ONLY the translated text — no explanations, no wrapping in quotes.
+4. Do NOT add any markdown formatting (no ** bold **, no * italics *, no other markup). Preserve the exact formatting of the original text.
 
 Text:
 ${textToTranslate}`;
@@ -327,7 +328,9 @@ ${textToTranslate}`;
     }
 
     // Only remove quotation marks if they surround the entire message
-    const cleanedText = translatedText.replace(/^"(.*)"$/s, '$1').trim();
+    let cleanedText = translatedText.replace(/^"(.*)"$/s, '$1').trim();
+    // Safety: strip markdown bold/italic injected by translation LLM
+    cleanedText = cleanedText.replace(/\*\*/g, '').trim();
 
     // Cache the successful translation
     if (cleanedText && cleanedText.length > 0) {


### PR DESCRIPTION
…, geo)

- Trivia: generates questions natively in botlang language with correct_answer_english for verification
- Riddle: generates riddles natively with riddle_answer_english for verification
- Geo: generates clues, follow-ups, and reveals natively in target language
- All games skip redundant post-generation translation for natively generated content
- Fixed markdown injection bug in translation utility (added prompt rule + safety strip)
- Answer verification still routes through English for reliability (Option A)